### PR TITLE
Solve txpower spikes during minstrel(_ht) sampling with only fixed_txpower

### DIFF
--- a/src/9978-rc80211-Apply-fixed_txpower-also-for-sampling-packet.patch
+++ b/src/9978-rc80211-Apply-fixed_txpower-also-for-sampling-packet.patch
@@ -1,0 +1,56 @@
+From: Sven Eckelmann <sven@narfation.org>
+Date: Wed, 22 Jul 2020 18:33:46 +0200
+Subject: mac80211: minstrel(_ht): Apply fixed_txpower also for sampling packets
+
+We must not use suddenly a higher txpower for sampling packets when the
+peer fixed txpower is set to a lower txpower. Otherwise the remote rx might
+get saturated and can no longer receive the packets we used for sampling.
+As result, the sampling fails not because of the rate but of a suddenly
+changing txpower.
+
+Signed-off-by: Sven Eckelmann <sven@narfation.org>
+
+diff --git a/net/mac80211/rc80211_minstrel.c b/net/mac80211/rc80211_minstrel.c
+index 9ee8e10475887fe73cf9587444e449546b171033..2f93192faee109c86c21473ef8b8a23f9b2fe728 100644
+--- a/net/mac80211/rc80211_minstrel.c
++++ b/net/mac80211/rc80211_minstrel.c
+@@ -388,12 +388,12 @@ minstrel_get_rate(void *priv, struct ieee80211_sta *sta,
+ 	mi->total_packets++;
+ 
+ #ifdef CPTCFG_MAC80211_DEBUGFS
+-	if ((mp->fixed_rate_idx != -1) || (mi->fixed_txrate != -1)) {
+-		/* use fixed txpower for rate sampling packets if set */
+-		if (mi->fixed_txpower != 255)
+-			info->control.txpower = mi->fixed_txpower;
++	/* use fixed txpower for rate sampling packets if set */
++	if (mi->fixed_txpower != 255)
++		info->control.txpower = mi->fixed_txpower;
++
++	if ((mp->fixed_rate_idx != -1) || (mi->fixed_txrate != -1))
+ 		return;
+-	}
+ #endif
+ 
+ 	/* Don't use EAPOL frames for sampling on non-mrr hw */
+diff --git a/net/mac80211/rc80211_minstrel_ht.c b/net/mac80211/rc80211_minstrel_ht.c
+index 916a999d2c1969f1d1d20f019ace0ad674db63b4..9511e29ec7a3d06d34a40d2d02803ac9cb5d967d 100644
+--- a/net/mac80211/rc80211_minstrel_ht.c
++++ b/net/mac80211/rc80211_minstrel_ht.c
+@@ -1087,12 +1087,12 @@ minstrel_ht_get_rate(void *priv, struct ieee80211_sta *sta, void *priv_sta,
+ 	info->flags |= mi->tx_flags;
+ 
+ #ifdef CPTCFG_MAC80211_DEBUGFS
+-	if ((mp->fixed_rate_idx != -1) || (msp->fixed_txrate != -1)) {
+-		/* use fixed txpower for rate sampling packets if set */
+-		if (msp->fixed_txpower != 255)
+-			info->control.txpower = msp->fixed_txpower;
++	/* use fixed txpower for rate sampling packets if set */
++	if (msp->fixed_txpower != 255)
++		info->control.txpower = msp->fixed_txpower;
++
++	if ((mp->fixed_rate_idx != -1) || (msp->fixed_txrate != -1))
+ 		return;
+-	}
+ #endif
+ 
+ 	/* Don't use EAPOL frames for sampling on non-mrr hw */


### PR DESCRIPTION
It was noticed that my high power ath9k device had sudden txpower burst which completely ruined the transmission to my remote device because its ADC was completely saturated. This resulted in rather low throughput because these high power packets were minstrel(_ht) sample packets. So the device never reached its expected high MCS rates.